### PR TITLE
Add marp

### DIFF
--- a/roquix/packages/marp.scm
+++ b/roquix/packages/marp.scm
@@ -1,0 +1,34 @@
+(define-module
+  (roquix packages marp)
+  #:use-module (guix packages)
+  #:use-module ((guix licenses)  #:prefix license:)
+  #:use-module (guix download)
+  #:use-module (nonguix build-system binary)
+  #:use-module (gnu packages base)
+  #:use-module (gnu packages gcc))
+
+(define-public marp-cli
+  (package
+   (name "marp-cli")
+   (version "2.2.2")
+   (source (origin
+            (method url-fetch)
+            (uri (string-append "https://github.com/marp-team/marp-cli/releases/download/"
+                                version "/marp-cli-v" version "-linux.tar.gz"))
+            (sha256
+             (base32
+              "1324afphj234yky9ckwrhhg7qhvaj08i5gl76qk787mdpmi9zrsa"))))
+   (build-system binary-build-system)
+   (arguments '(#:install-plan
+                '(("marp" "bin/"))
+                #:patchelf-plan
+                '(("marp" ("gcc" "glibc")))
+                #:validate-runpath? #f))
+   (inputs
+    `((,gcc "lib")
+      ,glibc))
+   (home-page "https://marp.app")
+   (synopsis "Markdown Presentation Ecosystem")
+   (description "Marp (also known as the Markdown Presentation Ecosystem) provides an intuitive experience for creating beautiful slide decks.
+You only have to focus on writing your story in a Markdown document.")
+   (license license:expat)))


### PR DESCRIPTION
There is error on `validate-runpath` phase:
```
/gnu/store/j4ax2di2z3n78rc6mvybm1zjcn88i12x-marp-cli-2.2.2/bin/marp: error: depends on '', which cannot be found in RUNPATH ()
```

When ignore it, get error when runtime:
```
marp: marp: no version information available (required by marp)
marp: symbol lookup error: marp: undefined symbol: , version
```