### PR TITLE
Improve Logseq AppImage packaging

### DIFF
--- a/roquix/packages/logseq.scm
+++ b/roquix/packages/logseq.scm
@@ -12,15 +12,31 @@
     (version "0.7.6")
     (source (origin
              (method url-fetch)
-             (uri (string-append "https://github.com/logseq/logseq/releases/download/"
-                                 version "/Logseq-linux-x64-" version ".AppImage"))
+             (uri (let ((appimage (string-append "Logseq-linux-x64-" version ".AppImage")))
+                    (string-append "https://github.com/logseq/logseq/releases/download/"
+                                   version "/" appimage)))
              (sha256
               (base32
                "0ci6x9bq5jqhwx83mw78k9029wddjy7i6164n4jgbrhkjk98x06x"))))
     (build-system binary-build-system)
-    (arguments `(#:install-plan
-                 '((,(string-append "Logseq-linux-x64-" version ".AppImage") "bin/"))))
+    (arguments
+     (let ((appimage (string-append "Logseq-linux-x64-" version ".AppImage")))
+       `(#:install-plan
+         `(((,appimage) "bin/"))
+         #:phases
+         (modify-phases %standard-phases
+           (add-after 'install 'rename-appimage
+             (lambda* (#:key outputs #:allow-other-keys)
+               (let* ((out (assoc-ref outputs "out"))
+                      (bin (string-append out "/bin/"))
+                      (installed (string-append bin ,appimage))
+                      (target (string-append bin "logseq")))
+                 (rename-file installed target)
+                 (chmod target #o755)
+                 #t)))))))
+    (supported-systems '("x86_64-linux"))
     (home-page "https://logseq.com/")
     (synopsis "A privacy-first, open-source platform for knowledge management and collaboration")
-    (description "A privacy-first, open-source platform for knowledge management and collaboration.")
+    (description
+     "A privacy-first, open-source platform for knowledge management and collaboration.")
     (license license:agpl3)))


### PR DESCRIPTION
## Summary
- ensure the Logseq AppImage is installed under a consistent `logseq` name and marked executable
- limit the binary package to x86_64-linux where the upstream artifact exists

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68ff9cb63764832aa2ea20fed610ff71